### PR TITLE
Fix no ARM64 natives for Linux nuget

### DIFF
--- a/tools/nuget/generate_nuspec_for_native_nuget.py
+++ b/tools/nuget/generate_nuspec_for_native_nuget.py
@@ -66,7 +66,7 @@ def generate_file_list_for_ep(nuget_artifacts_dir, ep, files_list):
                     if child_file.is_file() and child_file.suffix == '.dylib' and not is_versioned_dylib:
                         files_list.append('<file src="' + str(child_file) +
                                           '" target="runtimes/osx.10.14-%s/native"/>' % cpu_arch)
-        for cpu_arch in ['x64', 'aarch64']:
+        for cpu_arch in ['x64', 'arm64']:
             if child.name == get_package_name('linux', cpu_arch, ep):
                 child = child / 'lib'
                 if cpu_arch == 'x86_64':


### PR DESCRIPTION
Change from aarch64 to arm64 for natives in nuget packages.

**Description**:

Fix missing natives when publishing for RID `linux-arm64`

**Motivation and Context**

https://github.com/microsoft/onnxruntime/discussions/10624
